### PR TITLE
make generated VMDKs compatible with VirtualBox

### DIFF
--- a/VMDKstream.py
+++ b/VMDKstream.py
@@ -55,7 +55,8 @@ MARKER_FOOTER = 3 # footer (repeat of header with final info)
 SECTOR_SIZE = 512
 
 # Descriptor Template
-image_descriptor_template='''# Description file created by VMDK stream converter
+image_descriptor_template='''# Disk Descriptor File
+# Description file created by VMDK stream converter
 version=1
 # Believe this is random
 CID=7e5b80a7


### PR DESCRIPTION
VirtualBox only accepts VMDKs if the header starts with this string:
  # Disk Descriptor File
...or this string:
  # Disk DescriptorFile